### PR TITLE
Add support for a default biome property

### DIFF
--- a/slimeworldmanager-api/src/main/java/com/grinderwolf/swm/api/world/properties/SlimeProperties.java
+++ b/slimeworldmanager-api/src/main/java/com/grinderwolf/swm/api/world/properties/SlimeProperties.java
@@ -38,5 +38,7 @@ public class SlimeProperties {
 
     });
 
-    public static final SlimeProperty[] VALUES = { SPAWN_X, SPAWN_Y, SPAWN_Z, DIFFICULTY, ALLOW_MONSTERS, ALLOW_ANIMALS, PVP, ENVIRONMENT, WORLD_TYPE };
+    public static final SlimeProperty DEFAULT_BIOME = new SlimeProperty("defaultBiome", PropertyType.STRING, "minecraft:plains");
+
+    public static final SlimeProperty[] VALUES = { SPAWN_X, SPAWN_Y, SPAWN_Z, DIFFICULTY, ALLOW_MONSTERS, ALLOW_ANIMALS, PVP, ENVIRONMENT, WORLD_TYPE, DEFAULT_BIOME };
 }

--- a/slimeworldmanager-nms-v1_16_R1/src/main/java/com/grinderwolf/swm/nms/v1_16_R1/CustomNBTStorage.java
+++ b/slimeworldmanager-nms-v1_16_R1/src/main/java/com/grinderwolf/swm/nms/v1_16_R1/CustomNBTStorage.java
@@ -2,15 +2,15 @@ package com.grinderwolf.swm.nms.v1_16_R1;
 
 import com.flowpowered.nbt.CompoundTag;
 import com.grinderwolf.swm.api.world.SlimeWorld;
+import com.grinderwolf.swm.api.world.properties.SlimeProperties;
+import com.grinderwolf.swm.api.world.properties.SlimePropertyMap;
 import com.grinderwolf.swm.nms.CraftSlimeWorld;
-import net.minecraft.server.v1_16_R1.Convertable;
-import net.minecraft.server.v1_16_R1.EntityHuman;
-import net.minecraft.server.v1_16_R1.GameRules;
-import net.minecraft.server.v1_16_R1.MinecraftServer;
-import net.minecraft.server.v1_16_R1.NBTTagCompound;
-import net.minecraft.server.v1_16_R1.WorldData;
-import net.minecraft.server.v1_16_R1.WorldNBTStorage;
+import com.mojang.serialization.Lifecycle;
+import net.minecraft.server.v1_16_R1.*;
 import lombok.Getter;
+
+import java.util.Objects;
+import java.util.Properties;
 
 @Getter
 public class CustomNBTStorage extends WorldNBTStorage {
@@ -28,7 +28,17 @@ public class CustomNBTStorage extends WorldNBTStorage {
 
     public WorldData getWorldData() {
         if (worldData == null) {
-            worldData = new CustomWorldData((CraftSlimeWorld) world);
+            SlimePropertyMap propertyMap = world.getPropertyMap();
+            Properties properties = new Properties();
+            String defaultBiome = propertyMap.getString(SlimeProperties.DEFAULT_BIOME);
+            String generatorString = "{\"structures\":{\"structures\":{}},\"biome\":\"" + defaultBiome + "\",\"layers\":[]}";
+
+            properties.put("generator-settings", generatorString);
+            properties.put("level-type", "FLAT");
+
+            GeneratorSettings generatorSettings = GeneratorSettings.a(properties);
+
+            worldData = new CustomWorldData((CraftSlimeWorld) world, generatorSettings);
         }
 
         return worldData;

--- a/slimeworldmanager-nms-v1_16_R1/src/main/java/com/grinderwolf/swm/nms/v1_16_R1/CustomWorldData.java
+++ b/slimeworldmanager-nms-v1_16_R1/src/main/java/com/grinderwolf/swm/nms/v1_16_R1/CustomWorldData.java
@@ -6,22 +6,16 @@ import com.grinderwolf.swm.nms.CraftSlimeWorld;
 import com.mojang.serialization.Lifecycle;
 import lombok.Getter;
 
-import net.minecraft.server.v1_16_R1.BlockPosition;
-import net.minecraft.server.v1_16_R1.DedicatedServer;
-import net.minecraft.server.v1_16_R1.EnumDifficulty;
-import net.minecraft.server.v1_16_R1.EnumGamemode;
-import net.minecraft.server.v1_16_R1.GameRules;
+import net.minecraft.server.v1_16_R1.*;
 import net.minecraft.server.v1_16_R1.GameRules.GameRuleKey;
 import net.minecraft.server.v1_16_R1.GameRules.GameRuleValue;
-import net.minecraft.server.v1_16_R1.MinecraftServer;
-import net.minecraft.server.v1_16_R1.NBTTagCompound;
-import net.minecraft.server.v1_16_R1.WorldDataServer;
-import net.minecraft.server.v1_16_R1.WorldSettings;
 import org.bukkit.WorldType;
 import org.bukkit.craftbukkit.v1_16_R1.CraftWorld;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.Properties;
 
 @Getter
 public class CustomWorldData extends WorldDataServer {
@@ -29,7 +23,7 @@ public class CustomWorldData extends WorldDataServer {
     private final CraftSlimeWorld world;
     private final WorldType type;
 
-    CustomWorldData(CraftSlimeWorld world) {
+    CustomWorldData(CraftSlimeWorld world, GeneratorSettings generatorSettings) {
         super(new WorldSettings(
                 world.getName(),
                 EnumGamemode.NOT_SET,
@@ -39,7 +33,7 @@ public class CustomWorldData extends WorldDataServer {
                 new GameRules(),
                 MinecraftServer.getServer().datapackconfiguration
             ),
-            ((DedicatedServer)MinecraftServer.getServer()).getDedicatedServerProperties().generatorSettings,
+            generatorSettings,
             Lifecycle.stable()
         );
 

--- a/slimeworldmanager-nms-v1_16_R1/src/main/java/com/grinderwolf/swm/nms/v1_16_R1/v1_16_R1SlimeNMS.java
+++ b/slimeworldmanager-nms-v1_16_R1/src/main/java/com/grinderwolf/swm/nms/v1_16_R1/v1_16_R1SlimeNMS.java
@@ -206,7 +206,8 @@ public class v1_16_R1SlimeNMS implements SlimeNMS {
         LOGGER.debug("Server-world: " + world.getName());
         LOGGER.debug("Server-DM: " + dimensionManager);
         LOGGER.debug("Server-env: " + env.getId());
-        LOGGER.debug("Server-CG: " + worldData.getGeneratorSettings());
+        LOGGER.debug("Server-GS: " + worldData.getGeneratorSettings());
+        LOGGER.debug("Server-CG: " + worldData.getGeneratorSettings().getChunkGenerator());
         LOGGER.debug("Server-WS: " + worldData);
         LOGGER.debug("Server-Dir: " + conversionSession.folder.toString());
         LOGGER.debug("Server-DM: " + dimensionManager);

--- a/slimeworldmanager-plugin/src/main/java/com/grinderwolf/swm/plugin/SWMPlugin.java
+++ b/slimeworldmanager-plugin/src/main/java/com/grinderwolf/swm/plugin/SWMPlugin.java
@@ -274,6 +274,7 @@ public class SWMPlugin extends JavaPlugin implements SlimePlugin {
         propertyMap.setBoolean(SlimeProperties.ALLOW_ANIMALS, properties.allowAnimals());
         propertyMap.setBoolean(SlimeProperties.PVP, properties.isPvp());
         propertyMap.setString(SlimeProperties.ENVIRONMENT, properties.getEnvironment());
+        propertyMap.setString(SlimeProperties.DEFAULT_BIOME, "minecraft:plains");
 
         return propertyMap;
     }

--- a/slimeworldmanager-plugin/src/main/java/com/grinderwolf/swm/plugin/config/WorldData.java
+++ b/slimeworldmanager-plugin/src/main/java/com/grinderwolf/swm/plugin/config/WorldData.java
@@ -33,6 +33,8 @@ public class WorldData {
     private String environment = "NORMAL";
     @Setting("worldType")
     private String worldType = "DEFAULT";
+    @Setting("defaultBiome")
+    private String defaultBiome = "";
 
     @Setting("loadOnStartup")
     private boolean loadOnStartup = true;
@@ -88,6 +90,7 @@ public class WorldData {
         propertyMap.setBoolean(SlimeProperties.PVP, pvp);
         propertyMap.setString(SlimeProperties.ENVIRONMENT, environment);
         propertyMap.setString(SlimeProperties.WORLD_TYPE, worldType);
+        propertyMap.setString(SlimeProperties.DEFAULT_BIOME, defaultBiome);
 
         return propertyMap;
     }

--- a/slimeworldmanager-plugin/src/main/java/com/grinderwolf/swm/plugin/config/WorldData.java
+++ b/slimeworldmanager-plugin/src/main/java/com/grinderwolf/swm/plugin/config/WorldData.java
@@ -34,7 +34,7 @@ public class WorldData {
     @Setting("worldType")
     private String worldType = "DEFAULT";
     @Setting("defaultBiome")
-    private String defaultBiome = "";
+    private String defaultBiome = "minecraft:plains";
 
     @Setting("loadOnStartup")
     private boolean loadOnStartup = true;


### PR DESCRIPTION
The biome is used for the empty generated chunks, useful for keeping consistency with the rest of your maps.