### PR TITLE
Remove unneeded heightmap block lookups

### DIFF
--- a/slimeworldmanager-nms-v1_16_R1/src/main/java/com/grinderwolf/swm/nms/v1_16_R1/CustomWorldServer.java
+++ b/slimeworldmanager-nms-v1_16_R1/src/main/java/com/grinderwolf/swm/nms/v1_16_R1/CustomWorldServer.java
@@ -289,7 +289,11 @@ public class CustomWorldServer extends WorldServer {
             }
         }
 
-        HeightMap.a(nmsChunk, unsetHeightMaps);
+        // Don't try to populate heightmaps if there are none.
+        // Does a crazy amount of block lookups
+        if (!unsetHeightMaps.isEmpty()) {
+            HeightMap.a(nmsChunk, unsetHeightMaps);
+        }
         LOGGER.debug("Loaded chunk (" + pos.x + ", " + pos.z + ") on world " + slimeWorld.getName());
 
         return nmsChunk;

--- a/slimeworldmanager-nms-v1_16_R3/src/main/java/com/grinderwolf/swm/nms/v1_16_R3/CustomWorldServer.java
+++ b/slimeworldmanager-nms-v1_16_R3/src/main/java/com/grinderwolf/swm/nms/v1_16_R3/CustomWorldServer.java
@@ -258,7 +258,11 @@ public class CustomWorldServer extends WorldServer {
             }
         }
 
-        HeightMap.a(nmsChunk, unsetHeightMaps);
+        // Don't try to populate heightmaps if there are none.
+        // Does a crazy amount of block lookups
+        if (!unsetHeightMaps.isEmpty()) {
+            HeightMap.a(nmsChunk, unsetHeightMaps);
+        }
 
         return nmsChunk;
     }

--- a/slimeworldmanager-nms-v1_17_R1/src/main/java/com/grinderwolf/swm/nms/v1_17_R1/CustomWorldServer.java
+++ b/slimeworldmanager-nms-v1_17_R1/src/main/java/com/grinderwolf/swm/nms/v1_17_R1/CustomWorldServer.java
@@ -287,7 +287,11 @@ public class CustomWorldServer extends WorldServer {
             }
         }
 
-        HeightMap.a(nmsChunk, unsetHeightMaps);
+        // Don't try to populate heightmaps if there are none.
+        // Does a crazy amount of block lookups
+        if (!unsetHeightMaps.isEmpty()) {
+            HeightMap.a(nmsChunk, unsetHeightMaps);
+        }
 
         return nmsChunk;
     }

--- a/slimeworldmanager-nms-v1_17_R2/src/main/java/com/grinderwolf/swm/nms/v1_17_R2/CustomWorldServer.java
+++ b/slimeworldmanager-nms-v1_17_R2/src/main/java/com/grinderwolf/swm/nms/v1_17_R2/CustomWorldServer.java
@@ -287,7 +287,11 @@ public class CustomWorldServer extends WorldServer {
             }
         }
 
-        HeightMap.a(nmsChunk, unsetHeightMaps);
+        // Don't try to populate heightmaps if there are none.
+        // Does a crazy amount of block lookups
+        if (!unsetHeightMaps.isEmpty()) {
+            HeightMap.a(nmsChunk, unsetHeightMaps);
+        }
 
         return nmsChunk;
     }


### PR DESCRIPTION
Despite there being no unset height maps it will still iterate through the entire chunk.


Here is the mojang mapped method. 

```java
public static void primeHeightmaps(ChunkAccess chunk, Set<Heightmap.Types> types) {
        int i = types.size();
        ObjectList<Heightmap> objectList = new ObjectArrayList(i);
        ObjectListIterator<Heightmap> objectListIterator = objectList.iterator();
        int j = chunk.getHighestSectionPosition() + 16;
        MutableBlockPos mutableBlockPos = new MutableBlockPos();
     
       // All this iteration
        for(int k = 0; k < 16; ++k) {
            for(int l = 0; l < 16; ++l) {
                Iterator var9 = types.iterator();
 
               // This will not run because the iterator is empty
                while(var9.hasNext()) {
                    Heightmap.Types types2 = (Heightmap.Types)var9.next();
                    objectList.add(chunk.getOrCreateHeightmapUnprimed(types2));
                }
                        
                for(int m = j - 1; m >= chunk.getMinBuildHeight(); --m) {
                    mutableBlockPos.set(k, m, l);
                   // This still runs!!!
                    BlockState blockState = chunk.getBlockState(mutableBlockPos);
                    if (!blockState.is(Blocks.AIR)) {
                        while(objectListIterator.hasNext()) {
                            Heightmap heightmap = (Heightmap)objectListIterator.next();
                            if (heightmap.isOpaque.test(blockState)) {
                                heightmap.setHeight(k, l, m + 1);
                                objectListIterator.remove();
                            }
                        }

                        if (objectList.isEmpty()) {
                            break;
                        }

                        objectListIterator.back(i);
                    }
                }
            }
        }

    }
```