### PR TITLE
Add API to get currently loaded chunks

### DIFF
--- a/slimeworldmanager-api/src/main/java/com/grinderwolf/swm/api/world/SlimeWorld.java
+++ b/slimeworldmanager-api/src/main/java/com/grinderwolf/swm/api/world/SlimeWorld.java
@@ -11,6 +11,7 @@ import lombok.experimental.Wither;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Map;
 
 /**
  * In-memory representation of a SRF world.
@@ -41,6 +42,14 @@ public interface SlimeWorld {
      * @return The {@link SlimeChunk} that belongs to those coordinates.
      */
      SlimeChunk getChunk(int x, int z);
+
+    /**
+     * Returns a {@link Map} with every {@link SlimeChunk} that is
+     * currently loaded in this slime world.
+     *
+     * @return A {@link Map} containing every loaded chunk.
+     */
+     Map<Long, SlimeChunk> getChunks();
 
     /**
      * Returns the extra data of the world. Inside this {@link CompoundTag}


### PR DESCRIPTION
This simply adds api that exposes the inner list for loaded chunks. This is helpful if you want to delete, insert, or directly modify certain chunks that are loaded in the world. I was thinking about making this immutable, but getWorldMaps seems to be exposed directly as well? Unless Lombok returns an immutable collection, I am not sure.

Regardless, here it is.