### PR TITLE
Drop MongoDB Backups

### DIFF
--- a/slimeworldmanager-plugin/src/main/java/com/grinderwolf/swm/plugin/loaders/mongo/MongoLoader.java
+++ b/slimeworldmanager-plugin/src/main/java/com/grinderwolf/swm/plugin/loaders/mongo/MongoLoader.java
@@ -192,12 +192,11 @@ public class MongoLoader extends UpdatableLoader {
             GridFSBucket bucket = GridFSBuckets.create(mongoDatabase, collection);
             GridFSFile oldFile = bucket.find(Filters.eq("filename", worldName)).first();
 
+            bucket.uploadFromStream(worldName, new ByteArrayInputStream(serializedWorld));
+
             if (oldFile != null) {
-                // bucket.rename(oldFile.getObjectId(), worldName + "_backup");
                 bucket.delete(oldFile.getObjectId());
             }
-
-            bucket.uploadFromStream(worldName, new ByteArrayInputStream(serializedWorld));
 
             MongoCollection<Document> mongoCollection = mongoDatabase.getCollection(collection);
             Document worldDoc = mongoCollection.find(Filters.eq("name", worldName)).first();

--- a/slimeworldmanager-plugin/src/main/java/com/grinderwolf/swm/plugin/loaders/mongo/MongoLoader.java
+++ b/slimeworldmanager-plugin/src/main/java/com/grinderwolf/swm/plugin/loaders/mongo/MongoLoader.java
@@ -275,10 +275,8 @@ public class MongoLoader extends UpdatableLoader {
             bucket.delete(file.getObjectId());
 
             // Delete backup file
-            file = bucket.find(Filters.eq("filename", worldName + "_backup")).first();
-
-            if (file != null) {
-                bucket.delete(file.getObjectId());
+            for (GridFSFile backupFile : bucket.find(Filters.eq("filename", worldName + "_backup"))) {
+                bucket.delete(backupFile.getObjectId());
             }
 
             MongoCollection<Document> mongoCollection = mongoDatabase.getCollection(collection);

--- a/slimeworldmanager-plugin/src/main/java/com/grinderwolf/swm/plugin/loaders/mongo/MongoLoader.java
+++ b/slimeworldmanager-plugin/src/main/java/com/grinderwolf/swm/plugin/loaders/mongo/MongoLoader.java
@@ -193,7 +193,8 @@ public class MongoLoader extends UpdatableLoader {
             GridFSFile oldFile = bucket.find(Filters.eq("filename", worldName)).first();
 
             if (oldFile != null) {
-                bucket.rename(oldFile.getObjectId(), worldName + "_backup");
+                // bucket.rename(oldFile.getObjectId(), worldName + "_backup");
+                bucket.delete(oldFile.getObjectId());
             }
 
             bucket.uploadFromStream(worldName, new ByteArrayInputStream(serializedWorld));


### PR DESCRIPTION
This inherently fixes the problem with #77, where the MongoLoader is the only loader that has a backup feature. This just drops the backup feature in this loader entirely.