### PR TITLE
Add World Config creation for cloned worlds

### DIFF
--- a/slimeworldmanager-plugin/src/main/java/com/grinderwolf/swm/plugin/commands/sub/CloneWorldCmd.java
+++ b/slimeworldmanager-plugin/src/main/java/com/grinderwolf/swm/plugin/commands/sub/CloneWorldCmd.java
@@ -85,6 +85,9 @@ public class CloneWorldCmd implements Subcommand {
                     Bukkit.getScheduler().runTask(SWMPlugin.getInstance(), () -> {
                         try {
                             SWMPlugin.getInstance().generateWorld(slimeWorld);
+
+                            config.getWorlds().put(worldName, worldData);
+                            config.save();
                         } catch (IllegalArgumentException ex) {
                             sender.sendMessage(Logging.COMMAND_PREFIX + ChatColor.RED + "Failed to generate world " + worldName + ": " + ex.getMessage() + ".");
 


### PR DESCRIPTION
Fixes #62
Updates the Worlds Config when a world is cloned, duplicating the World Data values with the new world name as the key.