### PR TITLE
Add SlimeLoader#renameWorld

### DIFF
--- a/slimeworldmanager-api/src/main/java/com/grinderwolf/swm/api/loaders/SlimeLoader.java
+++ b/slimeworldmanager-api/src/main/java/com/grinderwolf/swm/api/loaders/SlimeLoader.java
@@ -91,6 +91,7 @@ public interface SlimeLoader {
      * @param newWorldName new name of the world
      *
      * @throws UnknownWorldException if the world could not be found.
+     * @throws IOException           if the world could not be renamed.
      */
-    boolean renameWorld(String oldWorldName, String newWorldName) throws UnknownWorldException;
+    boolean renameWorld(String oldWorldName, String newWorldName) throws UnknownWorldException, IOException;
 }

--- a/slimeworldmanager-api/src/main/java/com/grinderwolf/swm/api/loaders/SlimeLoader.java
+++ b/slimeworldmanager-api/src/main/java/com/grinderwolf/swm/api/loaders/SlimeLoader.java
@@ -84,4 +84,13 @@ public interface SlimeLoader {
      */
     void deleteWorld(String worldName) throws UnknownWorldException, IOException;
 
+    /**
+     * Renames a world in the data source.
+     *
+     * @param oldWorldName current (old) name of the world
+     * @param newWorldName new name of the world
+     *
+     * @throws UnknownWorldException if the world could not be found.
+     */
+    boolean renameWorld(String oldWorldName, String newWorldName) throws UnknownWorldException;
 }

--- a/slimeworldmanager-plugin/src/main/java/com/grinderwolf/swm/plugin/loaders/file/FileLoader.java
+++ b/slimeworldmanager-plugin/src/main/java/com/grinderwolf/swm/plugin/loaders/file/FileLoader.java
@@ -174,4 +174,9 @@ public class FileLoader implements SlimeLoader {
             }
         }
     }
+
+    @Override
+    public boolean renameWorld(String oldWorldName, String newWorldName) {
+        return true;
+    }
 }

--- a/slimeworldmanager-plugin/src/main/java/com/grinderwolf/swm/plugin/loaders/file/FileLoader.java
+++ b/slimeworldmanager-plugin/src/main/java/com/grinderwolf/swm/plugin/loaders/file/FileLoader.java
@@ -5,7 +5,6 @@ import com.grinderwolf.swm.api.exceptions.WorldInUseException;
 import com.grinderwolf.swm.api.loaders.SlimeLoader;
 import com.grinderwolf.swm.plugin.log.Logging;
 import org.apache.commons.io.FileUtils;
-import org.bukkit.Bukkit;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -13,7 +12,6 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.channels.FileChannel;
-import java.nio.channels.FileLock;
 import java.nio.channels.OverlappingFileLockException;
 import java.nio.file.NotDirectoryException;
 import java.util.*;
@@ -176,7 +174,15 @@ public class FileLoader implements SlimeLoader {
     }
 
     @Override
-    public boolean renameWorld(String oldWorldName, String newWorldName) {
-        return true;
+    public boolean renameWorld(String oldWorldName, String newWorldName) throws IOException {
+        if(this.isWorldLocked(oldWorldName)) {
+            return false;
+        }
+
+        return this.getWorldDir(oldWorldName).renameTo(this.getWorldDir(newWorldName));
+    }
+
+    private File getWorldDir(String worldName) {
+        return new File(this.worldDir, worldName + ".slime");
     }
 }

--- a/slimeworldmanager-plugin/src/main/java/com/grinderwolf/swm/plugin/loaders/mysql/MysqlLoader.java
+++ b/slimeworldmanager-plugin/src/main/java/com/grinderwolf/swm/plugin/loaders/mysql/MysqlLoader.java
@@ -289,4 +289,9 @@ public class MysqlLoader extends UpdatableLoader {
             throw new IOException(ex);
         }
     }
+
+    @Override
+    public boolean renameWorld(String oldWorldName, String newWorldName) {
+        return true;
+    }
 }

--- a/slimeworldmanager-plugin/src/main/java/com/grinderwolf/swm/plugin/loaders/redis/RedisLoader.java
+++ b/slimeworldmanager-plugin/src/main/java/com/grinderwolf/swm/plugin/loaders/redis/RedisLoader.java
@@ -90,6 +90,6 @@ public class RedisLoader implements SlimeLoader {
 
     @Override
     public boolean renameWorld(String oldWorldName, String newWorldName) {
-        return true;
+        throw new UnsupportedOperationException("Redis support for renaming worlds has (yet) not been added.");
     }
 }

--- a/slimeworldmanager-plugin/src/main/java/com/grinderwolf/swm/plugin/loaders/redis/RedisLoader.java
+++ b/slimeworldmanager-plugin/src/main/java/com/grinderwolf/swm/plugin/loaders/redis/RedisLoader.java
@@ -87,4 +87,9 @@ public class RedisLoader implements SlimeLoader {
         }
         connection.del(WORLD_DATA_PREFIX + name, WORLD_LOCK_PREFIX + name);
     }
+
+    @Override
+    public boolean renameWorld(String oldWorldName, String newWorldName) {
+        return true;
+    }
 }


### PR DESCRIPTION
This PR allows to rename worlds by SlimeLoader#renameWorld

Redis support will be postponed.

to-do:

- [x] add mongo support 
- [x] add mysql support
(- [ ] add redis support)
- [x] add file support