### PR TITLE
Fix infinite while loop in unload command

### DIFF
--- a/slimeworldmanager-plugin/src/main/java/com/grinderwolf/swm/plugin/commands/sub/UnloadWorldCmd.java
+++ b/slimeworldmanager-plugin/src/main/java/com/grinderwolf/swm/plugin/commands/sub/UnloadWorldCmd.java
@@ -92,11 +92,12 @@ public class UnloadWorldCmd implements Subcommand {
 
         spawnLocation.setY(64);
         while (spawnLocation.getBlock().getType() != Material.AIR || spawnLocation.getBlock().getRelative(BlockFace.UP).getType() != Material.AIR) {
-            if(spawnLocation.getY() >= 256) {
-                spawnLocation.getWorld().getBlockAt(0, 64 ,0).setType(Material.BEDROCK);
-            }else {
+            if(spawnLocation.getY() >= 320) {
                 spawnLocation.add(0, 1, 0);
+                break;
             }
+
+            spawnLocation.add(0, 1, 0);
         }
         return spawnLocation;
     }


### PR DESCRIPTION
With the findValidDefaultSpawn method, if you were to have a spawn location that was completely filled with blocks above y = 64 all the way to max build height, it would create an infinite while loop and eventually crash the server. I fixed the issue and also raised the build height to 1.17 and 1.18 versions.