### PR TITLE
Fixes Paul19988/Advanced-Slime-World-Manager#128

### DIFF
--- a/slimeworldmanager-plugin/src/main/java/com/grinderwolf/swm/plugin/loaders/file/FileLoader.java
+++ b/slimeworldmanager-plugin/src/main/java/com/grinderwolf/swm/plugin/loaders/file/FileLoader.java
@@ -106,9 +106,7 @@ public class FileLoader implements SlimeLoader {
             }
         }
 
-        if (tempFile) {
-            worldFile.close();
-        }
+        worldFile.close();
     }
 
     @Override


### PR DESCRIPTION
Addresses #128

Closes the worldFile's RAF stream, I believe that the IOException: Stream Closed was occurring after the second shutdown was because on the first shutdown it would be a temp file (therefore the stream would be closed) but after that, it would no longer be a temp file and the stream would not be closed (resulting in the IOException). I initially thought it was something to do with the change to the JavaPluginLoader as mentioned previously in one of the Discord channels, but I don't think that is the issue (I forked Paper and removed the change, but the error still persisted). I believe that this error does not occur on MongoDB, MySQL, or Redis datasources and only on the File datasource.

More testing can be done to ensure everything works and everything is saved as normal (although it did save before even with the IOException).