### PR TITLE
Fix/1.19.2 world importer

### DIFF
--- a/slimeworldmanager-nms-v119-2/src/main/java/com/grinderwolf/swm/nms/v1192/v1192SlimeNMS.java
+++ b/slimeworldmanager-nms-v119-2/src/main/java/com/grinderwolf/swm/nms/v1192/v1192SlimeNMS.java
@@ -74,7 +74,7 @@ public class v1192SlimeNMS implements SlimeNMS {
         }
     }
 
-    private final byte worldVersion = 0x09;
+    private final byte worldVersion = 0x08;
 
     private boolean injectFakeDimensions = false;
 

--- a/slimeworldmanager-plugin/src/main/java/com/grinderwolf/swm/plugin/world/importer/WorldImporter.java
+++ b/slimeworldmanager-plugin/src/main/java/com/grinderwolf/swm/plugin/world/importer/WorldImporter.java
@@ -112,7 +112,7 @@ public class WorldImporter {
         propertyMap.setValue(SlimeProperties.SPAWN_X, data.getSpawnX());
         propertyMap.setValue(SlimeProperties.SPAWN_Y, data.getSpawnY());
         propertyMap.setValue(SlimeProperties.SPAWN_Z, data.getSpawnZ());
-        System.out.println(worldVersion);
+
         if (worldVersion != SWMPlugin.getInstance().getNms().getWorldVersion()) {
             throw new UnsupportedOperationException("Please ensure that this world is not outdated.");
         }

--- a/slimeworldmanager-plugin/src/main/java/com/grinderwolf/swm/plugin/world/importer/WorldImporter.java
+++ b/slimeworldmanager-plugin/src/main/java/com/grinderwolf/swm/plugin/world/importer/WorldImporter.java
@@ -112,7 +112,7 @@ public class WorldImporter {
         propertyMap.setValue(SlimeProperties.SPAWN_X, data.getSpawnX());
         propertyMap.setValue(SlimeProperties.SPAWN_Y, data.getSpawnY());
         propertyMap.setValue(SlimeProperties.SPAWN_Z, data.getSpawnZ());
-
+        System.out.println(worldVersion);
         if (worldVersion != SWMPlugin.getInstance().getNms().getWorldVersion()) {
             throw new UnsupportedOperationException("Please ensure that this world is not outdated.");
         }
@@ -275,7 +275,14 @@ public class WorldImporter {
                     .orElse(new ListTag<>("entities", TagType.TAG_COMPOUND, new ArrayList<>()))).getValue();
             sectionsTag = (ListTag<CompoundTag>) compound.getAsListTag("sections").get();
 
-            minSectionY = compound.getIntValue("yPos").orElseThrow();
+            Class<?> type = compound.getValue().get("yPos").getValue().getClass();
+
+            if (type == Byte.class) {
+                minSectionY = compound.getByteValue("yPos").orElseThrow();
+            } else {
+                minSectionY = compound.getIntValue("yPos").orElseThrow();
+            }
+
             maxSectionY = sectionsTag.getValue().stream().map(c -> c.getByteValue("Y").orElseThrow()).max(Byte::compareTo).orElse((byte) 0) + 1; // Add 1 to the section, as we serialize it with the 1 added.
         }
         SlimeChunkSection[] sectionArray = new SlimeChunkSection[maxSectionY - minSectionY];


### PR DESCRIPTION
[#] Fixed a bug which threw an error because PosY object is sometimes a byte instead of an int after upgrading from paper

[#] World version corrected, is in the 1.19.2 still 0x08