### PR TITLE
Set 1.19 and 1.19.2 worldVersions to 0x09

### DIFF
--- a/slimeworldmanager-nms-v119-2/src/main/java/com/grinderwolf/swm/nms/v1192/v1192SlimeNMS.java
+++ b/slimeworldmanager-nms-v119-2/src/main/java/com/grinderwolf/swm/nms/v1192/v1192SlimeNMS.java
@@ -74,7 +74,7 @@ public class v1192SlimeNMS implements SlimeNMS {
         }
     }
 
-    private final byte worldVersion = 0x08;
+    private final byte worldVersion = 0x09;
 
     private boolean injectFakeDimensions = false;
 

--- a/slimeworldmanager-nms-v119/src/main/java/com/grinderwolf/swm/nms/v119/v119SlimeNMS.java
+++ b/slimeworldmanager-nms-v119/src/main/java/com/grinderwolf/swm/nms/v119/v119SlimeNMS.java
@@ -75,7 +75,7 @@ public class v119SlimeNMS implements SlimeNMS {
         }
     }
 
-    private final byte worldVersion = 0x08;
+    private final byte worldVersion = 0x09;
 
     private boolean injectFakeDimensions = false;
 


### PR DESCRIPTION
1.19.1 has the worldVersion `0x09`, while 1.19 and 1.19.2 currently use the old `0x08` from 1.18.2.
As far as I'm concerned, the world format changed in 1.19 and has remained the same in both patch 1 and 2.
This PR sets the worldVersion of all three versions to `0x09` to prevent servers breaking when updating.